### PR TITLE
Add battery optimization for local LLM with auto-unload feature

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,10 +12,12 @@ import 'providers/habit_provider.dart';
 import 'providers/pulse_provider.dart';
 import 'providers/pulse_type_provider.dart';
 import 'providers/chat_provider.dart';
+import 'providers/local_ai_state_provider.dart';
 import 'screens/home_screen.dart';
 import 'screens/onboarding_screen.dart';
 import 'services/notification_service.dart';
 import 'services/ai_service.dart';
+import 'services/local_ai_service.dart';
 import 'services/debug_service.dart';
 import 'services/storage_service.dart';
 import 'services/feature_discovery_service.dart';
@@ -52,6 +54,15 @@ void main() async {
     } catch (e) {
       debugPrint('Warning: AI service initialization failed: $e');
       // Continue app launch even if AI service fails
+    }
+
+    // Initialize Local AI service to load timeout settings
+    try {
+      final localAIService = LocalAIService();
+      await localAIService.initialize();
+    } catch (e) {
+      debugPrint('Warning: Local AI service initialization failed: $e');
+      // Continue app launch even if Local AI service fails
     }
 
     // Initialize feature discovery service
@@ -133,6 +144,7 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => PulseProvider()),
         ChangeNotifierProvider(create: (_) => PulseTypeProvider()),
         ChangeNotifierProvider(create: (_) => ChatProvider()),
+        ChangeNotifierProvider(create: (_) => LocalAIStateProvider()),
       ],
       child: MaterialApp(
         title: 'MentorMe',

--- a/lib/providers/local_ai_state_provider.dart
+++ b/lib/providers/local_ai_state_provider.dart
@@ -1,0 +1,51 @@
+// lib/providers/local_ai_state_provider.dart
+// Provider to track Local AI state for UI indicators
+
+import 'package:flutter/foundation.dart';
+import '../services/local_ai_service.dart';
+
+class LocalAIStateProvider extends ChangeNotifier {
+  final LocalAIService _localAIService = LocalAIService();
+
+  LocalAIState _state = LocalAIState.idle;
+  LocalAIState get state => _state;
+
+  bool get isLoading => _state == LocalAIState.loading;
+  bool get isInferring => _state == LocalAIState.inferring;
+  bool get isActive => _state == LocalAIState.loading ||
+                       _state == LocalAIState.inferring;
+  bool get isReady => _state == LocalAIState.ready;
+  bool get isIdle => _state == LocalAIState.idle;
+
+  LocalAIStateProvider() {
+    // Listen to LocalAIService state changes
+    _localAIService.addStateListener(_onStateChanged);
+    // Initialize with current state
+    _state = _localAIService.state;
+  }
+
+  void _onStateChanged(LocalAIState newState) {
+    _state = newState;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _localAIService.removeStateListener(_onStateChanged);
+    super.dispose();
+  }
+
+  /// Get a user-friendly status message
+  String get statusMessage {
+    switch (_state) {
+      case LocalAIState.idle:
+        return 'Local AI: Not loaded';
+      case LocalAIState.loading:
+        return 'Local AI: Loading model...';
+      case LocalAIState.ready:
+        return 'Local AI: Ready';
+      case LocalAIState.inferring:
+        return 'Local AI: Thinking...';
+    }
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -11,6 +11,7 @@ import '../constants/app_strings.dart';
 import '../services/notification_service.dart';
 import '../services/ai_service.dart';
 import '../services/storage_service.dart';
+import '../widgets/local_ai_indicator.dart';
 import 'goals_screen.dart';
 import 'journal_screen.dart';
 import 'habits_screen.dart';
@@ -391,6 +392,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
           ],
         ),
         actions: [
+          const LocalAIIndicator(),
           if (showAIWarning)
             Tooltip(
               message: AppStrings.aiNotConfigured,

--- a/lib/services/local_ai_service.dart
+++ b/lib/services/local_ai_service.dart
@@ -1,9 +1,19 @@
 // lib/services/local_ai_service.dart
 // Service for on-device AI inference using MediaPipe LLM Inference API
 
+import 'dart:async';
 import 'package:flutter/services.dart';
 import 'debug_service.dart';
 import 'model_download_service.dart';
+import 'storage_service.dart';
+
+/// State of the local AI model
+enum LocalAIState {
+  idle,      // Model not loaded
+  loading,   // Model is being loaded
+  ready,     // Model loaded and ready
+  inferring, // Currently running inference
+}
 
 class LocalAIService {
   static final LocalAIService _instance = LocalAIService._internal();
@@ -12,11 +22,84 @@ class LocalAIService {
 
   final DebugService _debug = DebugService();
   final ModelDownloadService _modelService = ModelDownloadService();
+  final StorageService _storage = StorageService();
 
   static const platform = MethodChannel('com.mentorme/local_ai');
 
   bool _isModelLoaded = false;
   bool get isModelLoaded => _isModelLoaded;
+
+  LocalAIState _state = LocalAIState.idle;
+  LocalAIState get state => _state;
+
+  // Auto-unload configuration
+  Timer? _inactivityTimer;
+  DateTime? _lastActivity;
+  int _timeoutMinutes = 5; // Default 5 minutes
+
+  // State change callbacks
+  final List<void Function(LocalAIState)> _stateListeners = [];
+
+  /// Add a listener for state changes
+  void addStateListener(void Function(LocalAIState) listener) {
+    _stateListeners.add(listener);
+  }
+
+  /// Remove a state listener
+  void removeStateListener(void Function(LocalAIState) listener) {
+    _stateListeners.remove(listener);
+  }
+
+  /// Notify all listeners of state change
+  void _notifyStateChange(LocalAIState newState) {
+    _state = newState;
+    for (final listener in _stateListeners) {
+      listener(newState);
+    }
+  }
+
+  /// Initialize service and load timeout settings
+  Future<void> initialize() async {
+    _timeoutMinutes = await _storage.getLocalAITimeout() ?? 5;
+    await _debug.info('LocalAIService', 'Initialized with timeout: $_timeoutMinutes minutes');
+  }
+
+  /// Set auto-unload timeout in minutes (0 = disabled)
+  Future<void> setAutoUnloadTimeout(int minutes) async {
+    _timeoutMinutes = minutes;
+    await _storage.saveLocalAITimeout(minutes);
+    await _debug.info('LocalAIService', 'Auto-unload timeout set to: $minutes minutes');
+
+    // Restart timer with new timeout
+    if (_isModelLoaded) {
+      _resetInactivityTimer();
+    }
+  }
+
+  /// Get current auto-unload timeout in minutes
+  int get autoUnloadTimeout => _timeoutMinutes;
+
+  /// Reset the inactivity timer
+  void _resetInactivityTimer() {
+    _inactivityTimer?.cancel();
+    _lastActivity = DateTime.now();
+
+    // Don't start timer if timeout is 0 (disabled)
+    if (_timeoutMinutes <= 0) {
+      return;
+    }
+
+    _inactivityTimer = Timer(Duration(minutes: _timeoutMinutes), () async {
+      await _debug.info('LocalAIService', 'Auto-unloading model after $_timeoutMinutes minutes of inactivity');
+      await unloadModel();
+    });
+  }
+
+  /// Cancel the inactivity timer
+  void _cancelInactivityTimer() {
+    _inactivityTimer?.cancel();
+    _inactivityTimer = null;
+  }
 
   /// Validate the MediaPipe model without running inference
   /// This is safer for testing as it won't crash from inference issues
@@ -83,10 +166,13 @@ class LocalAIService {
   /// Load the MediaPipe model for inference
   Future<bool> loadModel() async {
     try {
+      _notifyStateChange(LocalAIState.loading);
+
       // Check if model is downloaded first
       final isDownloaded = await _modelService.isModelDownloaded();
       if (!isDownloaded) {
         await _debug.error('LocalAIService', 'Model not downloaded');
+        _notifyStateChange(LocalAIState.idle);
         throw Exception('Model not downloaded. Please download the model first.');
       }
 
@@ -107,8 +193,11 @@ class LocalAIService {
 
       if (_isModelLoaded) {
         await _debug.info('LocalAIService', 'Model loaded successfully');
+        _notifyStateChange(LocalAIState.ready);
+        _resetInactivityTimer();
       } else {
         await _debug.error('LocalAIService', 'Failed to load model');
+        _notifyStateChange(LocalAIState.idle);
       }
 
       return _isModelLoaded;
@@ -120,6 +209,7 @@ class LocalAIService {
         metadata: {'code': e.code, 'details': e.details, 'message': e.message},
       );
       _isModelLoaded = false;
+      _notifyStateChange(LocalAIState.idle);
       // Re-throw with more context for debugging
       throw Exception('Failed to load model: [${e.code}] ${e.message}');
     } catch (e, stackTrace) {
@@ -129,6 +219,7 @@ class LocalAIService {
         stackTrace: stackTrace.toString(),
       );
       _isModelLoaded = false;
+      _notifyStateChange(LocalAIState.idle);
       throw Exception('Failed to load model: ${e.toString()}');
     }
   }
@@ -144,6 +235,8 @@ class LocalAIService {
     }
 
     try {
+      _notifyStateChange(LocalAIState.inferring);
+
       await _debug.info('LocalAIService', 'Running inference', metadata: {
         'promptLength': prompt.length,
       });
@@ -157,6 +250,10 @@ class LocalAIService {
         'responseLength': response?.length ?? 0,
       });
 
+      // Reset inactivity timer after successful inference
+      _notifyStateChange(LocalAIState.ready);
+      _resetInactivityTimer();
+
       return response ?? 'No response from model';
     } on PlatformException catch (e, stackTrace) {
       await _debug.error(
@@ -165,6 +262,7 @@ class LocalAIService {
         stackTrace: stackTrace.toString(),
         metadata: {'code': e.code, 'details': e.details},
       );
+      _notifyStateChange(LocalAIState.ready);
       throw Exception('Inference failed: ${e.message}');
     } catch (e, stackTrace) {
       await _debug.error(
@@ -172,6 +270,7 @@ class LocalAIService {
         'Error during inference: ${e.toString()}',
         stackTrace: stackTrace.toString(),
       );
+      _notifyStateChange(LocalAIState.ready);
       throw Exception('Inference error: ${e.toString()}');
     }
   }
@@ -179,8 +278,10 @@ class LocalAIService {
   /// Unload the model to free memory
   Future<void> unloadModel() async {
     try {
+      _cancelInactivityTimer();
       await platform.invokeMethod('unloadModel');
       _isModelLoaded = false;
+      _notifyStateChange(LocalAIState.idle);
       await _debug.info('LocalAIService', 'Model unloaded');
     } on PlatformException catch (e, stackTrace) {
       await _debug.error(
@@ -189,5 +290,11 @@ class LocalAIService {
         stackTrace: stackTrace.toString(),
       );
     }
+  }
+
+  /// Clean up resources (call when service is being destroyed)
+  void dispose() {
+    _cancelInactivityTimer();
+    _stateListeners.clear();
   }
 }

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -312,4 +312,15 @@ class StorageService {
     final List<dynamic> jsonList = json.decode(jsonString);
     return jsonList.cast<Map<String, dynamic>>();
   }
+
+  // Save/Load Local AI Timeout (auto-unload setting)
+  Future<void> saveLocalAITimeout(int minutes) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('local_ai_timeout_minutes', minutes);
+  }
+
+  Future<int?> getLocalAITimeout() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt('local_ai_timeout_minutes');
+  }
 }

--- a/lib/widgets/local_ai_indicator.dart
+++ b/lib/widgets/local_ai_indicator.dart
@@ -1,0 +1,79 @@
+// lib/widgets/local_ai_indicator.dart
+// Visual indicator for Local AI status in app bar
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/local_ai_state_provider.dart';
+import '../services/local_ai_service.dart';
+
+class LocalAIIndicator extends StatelessWidget {
+  const LocalAIIndicator({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<LocalAIStateProvider>(
+      builder: (context, stateProvider, child) {
+        // Only show indicator when actively loading or inferring
+        if (!stateProvider.isActive) {
+          return const SizedBox.shrink();
+        }
+
+        return Padding(
+          padding: const EdgeInsets.only(right: 8.0),
+          child: Tooltip(
+            message: stateProvider.statusMessage,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(
+                      _getIndicatorColor(context, stateProvider.state),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  _getStatusText(stateProvider.state),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: _getIndicatorColor(context, stateProvider.state),
+                        fontWeight: FontWeight.w500,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  String _getStatusText(LocalAIState state) {
+    switch (state) {
+      case LocalAIState.loading:
+        return 'Loading';
+      case LocalAIState.inferring:
+        return 'Thinking';
+      case LocalAIState.ready:
+        return 'Ready';
+      case LocalAIState.idle:
+        return '';
+    }
+  }
+
+  Color _getIndicatorColor(BuildContext context, LocalAIState state) {
+    switch (state) {
+      case LocalAIState.loading:
+        return Colors.orange;
+      case LocalAIState.inferring:
+        return Theme.of(context).colorScheme.primary;
+      case LocalAIState.ready:
+        return Colors.green;
+      case LocalAIState.idle:
+        return Colors.grey;
+    }
+  }
+}


### PR DESCRIPTION
This commit implements automatic unloading of the local AI model after inactivity to save battery and memory. The model uses ~600MB of memory and GPU resources when loaded, which can drain battery if left running indefinitely.

Key features:
- Auto-unload timer with configurable timeout (default: 5 minutes)
- Transparent reload on next use (2-5 seconds)
- State tracking (idle, loading, ready, inferring) for UI indicators
- Visual loading indicator in app header bar
- User settings to configure timeout (0-15 minutes)

Changes:
- LocalAIService: Added timer, state management, and auto-unload logic
- LocalAIStateProvider: New provider for tracking LLM state changes
- LocalAIIndicator: New widget showing loading/inferring status
- AI Settings: Added battery optimization section with timeout config
- StorageService: Added methods to save/load timeout setting
- Updated documentation with battery optimization details

The feature is enabled by default with a 5-minute timeout, and can be disabled or adjusted in AI Settings > Battery Optimization.