### PR TITLE
Fix CI/CD build to use split APKs by architecture

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -74,13 +74,22 @@ jobs:
         continue-on-error: true  # Don't fail build if no tests exist
 
       - name: Build debug APK
-        run: flutter build apk --debug --target-platform android-arm,android-arm64
-        # Note: Targeting only ARM architectures (x86 is deprecated in Flutter 3.27+)
+        run: |
+          # Build split APKs by architecture (same as release workflow)
+          # This creates separate optimized APKs for each architecture
+          flutter build apk --debug --split-per-abi
+
+          echo "Built APKs:"
+          ls -lh build/app/outputs/flutter-apk/*-debug.apk
 
       - name: Build release APK
-        run: flutter build apk --release --target-platform android-arm,android-arm64
-        # Note: This will use debug signing if key.properties doesn't exist
-        # For production releases, configure GitHub Secrets for signing
+        run: |
+          # Build split APKs by architecture (same as release workflow)
+          # This creates separate optimized APKs for each architecture
+          flutter build apk --release --split-per-abi --shrink
+
+          echo "Built APKs:"
+          ls -lh build/app/outputs/flutter-apk/*-release.apk
 
       - name: Upload debug APK artifacts
         uses: actions/upload-artifact@v4
@@ -148,9 +157,12 @@ jobs:
         run: flutter pub get
 
       - name: Build App Bundle (AAB)
-        run: flutter build appbundle --release --target-platform android-arm,android-arm64
-        # Note: For Play Store publishing, you'll need to configure signing
-        # Targeting only ARM architectures (x86 is deprecated in Flutter 3.27+)
+        run: |
+          # Build App Bundle with ARM architectures (matches release workflow)
+          flutter build appbundle --release --target-platform android-arm,android-arm64
+
+          echo "Built App Bundle:"
+          ls -lh build/app/outputs/bundle/release/app-release.aab
 
       - name: Upload App Bundle artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Changed from fat APKs (--target-platform) to split APKs (--split-per-abi)
- Now matches release workflow behavior for consistency
- Improves installation reliability by creating separate APKs per architecture
- Added --shrink flag to release builds for optimization